### PR TITLE
Multi plane moc

### DIFF
--- a/moc/src/kokkos_moc.hpp
+++ b/moc/src/kokkos_moc.hpp
@@ -80,7 +80,7 @@ class KokkosMOC : public BaseMOC {
                 : angle_name(ang_name), ray_name(r_name), angle_index(ang_idx), nsegs(nseg), ray_group(group) {}
         };
 
-        std::vector<RayInfo> _read_ray_infos(int num_planes);
+        std::vector<RayInfo> _read_ray_infos();
         HViewKokkosLongRay1D _read_rays(std::vector<RayInfo> ray_infos);  // Read rays from the HDF5 file
         HViewKokkosRaySegment1D _read_segments(std::vector<RayInfo> ray_infos);  // Read rays from the HDF5 file
         void _get_xstr(const int num_fsr, const std::vector<int>& fsr_mat_id, const c5g7_library& library);  // Read xstr from XS library
@@ -95,7 +95,9 @@ class KokkosMOC : public BaseMOC {
         std::string _ray_sort;  // Ray sorting method
 
         // Sizes
+        int _num_planes;  // Number of planes to simulate
         int _nfsr;  // Number of FSRs
+        int _nfsr_per_plane;  // Number of FSRs per plane
         int _npol;  // Number of polar angles
         int _ng;  // Number of energy groups
         int _n_exp_intervals;  // Number of exponential table intervals
@@ -123,6 +125,7 @@ class KokkosMOC : public BaseMOC {
 
         // Ray data
         int _n_rays;  // Number of rays
+        int _n_rays_per_plane;  // Number of rays per plane
         int _max_segments;  // Maximum number of segments in any ray
         DViewKokkosRaySegment1D _d_segments;
         DViewKokkosLongRay1D _d_rays;

--- a/moc/src/kokkos_moc.hpp
+++ b/moc/src/kokkos_moc.hpp
@@ -80,7 +80,7 @@ class KokkosMOC : public BaseMOC {
                 : angle_name(ang_name), ray_name(r_name), angle_index(ang_idx), nsegs(nseg), ray_group(group) {}
         };
 
-        std::vector<RayInfo> _read_ray_infos();
+        std::vector<RayInfo> _read_ray_infos(int num_planes);
         HViewKokkosLongRay1D _read_rays(std::vector<RayInfo> ray_infos);  // Read rays from the HDF5 file
         HViewKokkosRaySegment1D _read_segments(std::vector<RayInfo> ray_infos);  // Read rays from the HDF5 file
         void _get_xstr(const int num_fsr, const std::vector<int>& fsr_mat_id, const c5g7_library& library);  // Read xstr from XS library

--- a/moc/src/main.cpp
+++ b/moc/src/main.cpp
@@ -125,6 +125,7 @@ int main(int argc, char* argv[]) {
         std::cout << "Device: " << parser.get_option("device") << std::endl;
         std::cout << "Precision: " << parser.get_option("precision") << std::endl;
         std::cout << "Ray sort: " << parser.get_option("ray_sort") << std::endl;
+        std::cout << "Number of Planes: " << parser.get_option("num_planes") << std::endl;
     } else {
         if (sweeper_type == "kokkos") {
             std::string device = parser.get_option("device");

--- a/moc/tests/test_kokkos_moc_pin_omp4_double.cpp
+++ b/moc/tests/test_kokkos_moc_pin_omp4_double.cpp
@@ -7,8 +7,8 @@
 #include "argument_parser.hpp"
 
 TEST(BasicTest, pin_7g_16a_3p_kokkos_double) {
-    const char* raw_args[] = {"exe", "data/pin_7g_16a_3p_serial.h5", "data/c5g7.xsl", "--sweeper", "kokkos", "--device", "openmp", "--kokkos-num-threads=4", "--precision", "double"};
-    int argc = 10;
+    const char* raw_args[] = {"exe", "data/pin_7g_16a_3p_serial.h5", "data/c5g7.xsl", "--sweeper", "kokkos", "--device", "openmp", "--kokkos-num-threads=4", "--precision", "double", "--ray_sort", "long"};
+    int argc = 12;
     char** args = const_cast<char**>(raw_args);
     Kokkos::initialize(argc, args);
     {

--- a/moc/tests/test_kokkos_moc_pin_omp4_single.cpp
+++ b/moc/tests/test_kokkos_moc_pin_omp4_single.cpp
@@ -7,8 +7,8 @@
 #include "argument_parser.hpp"
 
 TEST(BasicTest, pin_7g_16a_3p_kokkos_single) {
-    const char* raw_args[] = {"exe", "data/pin_7g_16a_3p_serial.h5", "data/c5g7.xsl", "--sweeper", "kokkos", "--device", "openmp", "--kokkos-num-threads=4", "--precision", "single"};
-    int argc = 10;
+    const char* raw_args[] = {"exe", "data/pin_7g_16a_3p_serial.h5", "data/c5g7.xsl", "--sweeper", "kokkos", "--device", "openmp", "--kokkos-num-threads=4", "--precision", "single", "--num_planes", "4"};
+    int argc = 12;
     char** args = const_cast<char**>(raw_args);
     Kokkos::initialize(argc, args);
     {
@@ -17,7 +17,7 @@ TEST(BasicTest, pin_7g_16a_3p_kokkos_single) {
         std::shared_ptr<BaseMOC> sweeper(new KokkosMOC<Kokkos::OpenMP, float>(parser));
         EigenSolver solver(parser, sweeper);
         solver.solve();
-        EXPECT_NEAR(solver.keff(), 1.325694203, 5.0e-7);
+        EXPECT_NEAR(solver.keff(), 1.325694203, 2.0e-6);
     }
     Kokkos::finalize();
 }

--- a/moc/tests/test_kokkos_moc_pin_serial_double.cpp
+++ b/moc/tests/test_kokkos_moc_pin_serial_double.cpp
@@ -7,8 +7,8 @@
 #include "argument_parser.hpp"
 
 TEST(BasicTest, pin_7g_16a_3p_kokkos_double) {
-    const char* raw_args[] = {"exe", "data/pin_7g_16a_3p_serial.h5", "data/c5g7.xsl", "--sweeper", "kokkos", "--device", "serial", "--precision", "double"};
-    int argc = 9;
+    const char* raw_args[] = {"exe", "data/pin_7g_16a_3p_serial.h5", "data/c5g7.xsl", "--sweeper", "kokkos", "--device", "serial", "--precision", "double", "--ray_sort", "none"};
+    int argc = 11;
     char** args = const_cast<char**>(raw_args);
     Kokkos::initialize(argc, args);
     {

--- a/moc/tests/test_kokkos_moc_pin_serial_single.cpp
+++ b/moc/tests/test_kokkos_moc_pin_serial_single.cpp
@@ -7,8 +7,8 @@
 #include "argument_parser.hpp"
 
 TEST(BasicTest, pin_7g_16a_3p_kokkos_single) {
-    const char* raw_args[] = {"exe", "data/pin_7g_16a_3p_serial.h5", "data/c5g7.xsl", "--sweeper", "kokkos", "--device", "serial", "--precision", "single"};
-    int argc = 9;
+    const char* raw_args[] = {"exe", "data/pin_7g_16a_3p_serial.h5", "data/c5g7.xsl", "--sweeper", "kokkos", "--device", "serial", "--precision", "single", "--ray_sort", "short"};
+    int argc = 11;
     char** args = const_cast<char**>(raw_args);
     Kokkos::initialize(argc, args);
     {

--- a/utils/src/argument_parser.cpp
+++ b/utils/src/argument_parser.cpp
@@ -276,6 +276,7 @@ ArgumentParser ArgumentParser::vera_gpu_moc_parser(const std::string& program_na
     parser.add_option("k_conv_crit", "K-eff convergence criteria threshold", "1e-8");
     parser.add_option("f_conv_crit", "Fission source convergence criteria threshold", "1e-8");
     parser.add_option("ray_sort", "Ray sorting method (none, long, short)", "none", {"none", "long", "short"});
+    parser.add_option("num_planes", "The number of planes to simulate", "1");
 
     return parser;
 }


### PR DESCRIPTION
Implements `--num_planes` option for KokkosMOC.  This causes the rays
and regions to be duplicated as if multiple planes were present
Testing included.  Manually testing shows approximately linear scaling
with the number of planes on small problems, indicating it's doing what's
expected.

Closes #53 